### PR TITLE
update tar as suggested by dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6213,9 +6213,9 @@
       }
     },
     "tar": {
-      "version": "4.4.17",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.17.tgz",
-      "integrity": "sha512-q7OwXq6NTdcYIa+k58nEMV3j1euhDhGCs/VRw9ymx/PbH0jtIM2+VTgDE/BW3rbLkrBUXs5fzEKgic5oUciu7g==",
+      "version": "4.4.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
       "requires": {
         "chownr": "^1.1.4",
         "fs-minipass": "^1.2.7",


### PR DESCRIPTION
Signed-off-by: Sally MacFarlane <sally.macfarlane@consensys.net>

Bumps tar from 4.4.17 to 4.4.19.

